### PR TITLE
Accept request content as "data"

### DIFF
--- a/build/pine.js
+++ b/build/pine.js
@@ -26,6 +26,9 @@ ResinPine = (function(_super) {
     if (params.gzip == null) {
       params.gzip = true;
     }
+    if ((params.data != null) && (params.body == null)) {
+      params.body = params.data;
+    }
     return request(params).spread(function(response, body) {
       if (utils.isSuccessfulResponse(response)) {
         return body;

--- a/lib/pine.coffee
+++ b/lib/pine.coffee
@@ -11,6 +11,10 @@ class ResinPine extends PinejsClientCore
 		params.json = true
 		params.gzip ?= true
 
+		# Support "data" attribute
+		if params.data? and not params.body?
+			params.body = params.data
+
 		request(params).spread (response, body) ->
 			return body if utils.isSuccessfulResponse(response)
 			throw new errors.ResinRequestError(body)

--- a/tests/pine.spec.coffee
+++ b/tests/pine.spec.coffee
@@ -44,3 +44,45 @@ describe 'Pine:', ->
 					expect(error).to.be.an.instanceof(Error)
 					expect(error.message).to.equal('Request error: Bar')
 					done()
+
+		describe 'given an endpoint that returns the body', ->
+
+			beforeEach ->
+				nock(settings.get('remoteUrl'))
+					.post('/body')
+					.reply 200, (uri, body) ->
+						return body
+
+			it 'should accept the body as "data"', (done) ->
+				pine._request
+					method: 'POST'
+					url: '/body'
+					data:
+						hello: 'world'
+				.then (body) ->
+					expect(body).to.deep.equal(hello: 'world')
+					done()
+
+			it 'should accept the body as "body"', (done) ->
+				pine._request
+					method: 'POST'
+					url: '/body'
+					body:
+						hello: 'world'
+				.then (body) ->
+					expect(body).to.deep.equal(hello: 'world')
+					done()
+
+			describe 'given both "data" and "body"', ->
+
+				it 'should give priority to "body"', (done) ->
+					pine._request
+						method: 'POST'
+						url: '/body'
+						data:
+							name: 'data'
+						body:
+							name: 'body'
+					.then (body) ->
+						expect(body).to.deep.equal(name: 'body')
+						done()


### PR DESCRIPTION
For legacy support.
