### PR TITLE
Don't throw ResinNotLoggedIn if there is an API key

### DIFF
--- a/build/pine.js
+++ b/build/pine.js
@@ -65,7 +65,7 @@ ResinPine = (function(superClass) {
 
   ResinPine.prototype._request = function(options) {
     return token.has().then(function(hasToken) {
-      if (!hasToken) {
+      if (!hasToken && _.isEmpty(process.env.RESIN_API_KEY)) {
         throw new errors.ResinNotLoggedIn();
       }
       return request.send(options).get('body');

--- a/lib/pine.coffee
+++ b/lib/pine.coffee
@@ -47,7 +47,8 @@ class ResinPine extends PinejsClientCore
 	###
 	_request: (options) ->
 		token.has().then (hasToken) ->
-			throw new errors.ResinNotLoggedIn() if not hasToken
+			if not hasToken and _.isEmpty(process.env.RESIN_API_KEY)
+				throw new errors.ResinNotLoggedIn()
 			return request.send(options).get('body')
 
 module.exports = new ResinPine

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "lodash": "^4.5.0",
     "pinejs-client": "^2.1.1",
     "resin-errors": "^2.0.0",
-    "resin-request": "^4.0.3",
+    "resin-request": "^4.1.1",
     "resin-token": "^2.4.0"
   }
 }

--- a/tests/pine.spec.coffee
+++ b/tests/pine.spec.coffee
@@ -36,16 +36,35 @@ describe 'Pine:', ->
 				describe 'given a simple GET endpoint', ->
 
 					beforeEach ->
-						nock(settings.get('apiUrl')).get('/foo').reply(200, hello: 'world')
+						nock(settings.get('apiUrl')).get('/foo').query(true).reply(200, hello: 'world')
 
 					afterEach ->
 						nock.cleanAll()
 
-					it 'should be rejected with an authentication error message', ->
-						promise = pine._request
-							method: 'GET'
-							url: '/foo'
-						m.chai.expect(promise).to.be.rejectedWith('You have to log in')
+					describe 'given there is no api key', ->
+
+						beforeEach ->
+							process.env.RESIN_API_KEY = ''
+
+						it 'should be rejected with an authentication error message', ->
+							promise = pine._request
+								method: 'GET'
+								url: '/foo'
+							m.chai.expect(promise).to.be.rejectedWith('You have to log in')
+
+					describe 'given there is an api key', ->
+
+						beforeEach ->
+							process.env.RESIN_API_KEY = '123456789'
+
+						afterEach ->
+							process.env.RESIN_API_KEY = ''
+
+						it 'should make the request successfully', ->
+							promise = pine._request
+								method: 'GET'
+								url: '/foo'
+							m.chai.expect(promise).to.become(hello: 'world')
 
 			describe 'given there is a token', ->
 


### PR DESCRIPTION
`resin-request` v4.1.0 introduces support for API keys by scanning the
`RESIN_API_KEY` environment variable.

Since Pine will not return an "Unauthorized" HTTP status code, we have to
rely on manually throwing a `ResinNotLoggedIn` error. This error was
currently thrown if there was no saved token, however we now must only
throw if there is no token AND there is no API key.
