### PR TITLE
Use Pine API absolute URL

### DIFF
--- a/build/pine.js
+++ b/build/pine.js
@@ -18,17 +18,21 @@ limitations under the License.
 /**
  * @module pine
  */
-var PinejsClientCore, Promise, ResinPine, _, errors, request, token,
+var PinejsClientCore, Promise, ResinPine, _, errors, request, settings, token, url,
   extend = function(child, parent) { for (var key in parent) { if (hasProp.call(parent, key)) child[key] = parent[key]; } function ctor() { this.constructor = child; } ctor.prototype = parent.prototype; child.prototype = new ctor(); child.__super__ = parent.prototype; return child; },
   hasProp = {}.hasOwnProperty;
 
 _ = require('lodash');
+
+url = require('url');
 
 Promise = require('bluebird');
 
 PinejsClientCore = require('pinejs-client/core')(_, Promise);
 
 request = require('resin-request');
+
+settings = require('resin-settings-client');
 
 token = require('resin-token');
 
@@ -77,5 +81,5 @@ ResinPine = (function(superClass) {
 })(PinejsClientCore);
 
 module.exports = new ResinPine({
-  apiPrefix: '/ewa/'
+  apiPrefix: url.resolve(settings.get('apiUrl'), '/ewa/')
 });

--- a/lib/pine.coffee
+++ b/lib/pine.coffee
@@ -19,9 +19,11 @@ limitations under the License.
 ###
 
 _ = require('lodash')
+url = require('url')
 Promise = require('bluebird')
 PinejsClientCore = require('pinejs-client/core')(_, Promise)
 request = require('resin-request')
+settings = require('resin-settings-client')
 token = require('resin-token')
 errors = require('resin-errors')
 
@@ -52,4 +54,4 @@ class ResinPine extends PinejsClientCore
 			return request.send(options).get('body')
 
 module.exports = new ResinPine
-	apiPrefix: '/ewa/'
+	apiPrefix: url.resolve(settings.get('apiUrl'), '/ewa/')

--- a/package.json
+++ b/package.json
@@ -30,8 +30,7 @@
     "gulp-util": "^3.0.1",
     "mocha": "^2.4.5",
     "mochainon": "^1.0.0",
-    "nock": "^7.2.1",
-    "resin-settings-client": "^3.0.0"
+    "nock": "^7.2.1"
   },
   "dependencies": {
     "bluebird": "^3.3.1",
@@ -39,6 +38,7 @@
     "pinejs-client": "^2.1.1",
     "resin-errors": "^2.0.0",
     "resin-request": "^4.1.1",
+    "resin-settings-client": "^3.0.0",
     "resin-token": "^2.4.0"
   }
 }

--- a/tests/pine.spec.coffee
+++ b/tests/pine.spec.coffee
@@ -12,7 +12,7 @@ describe 'Pine:', ->
 	describe '.apiPrefix', ->
 
 		it 'should equal /ewa/', ->
-			m.chai.expect(pine.apiPrefix).to.equal('/ewa/')
+			m.chai.expect(pine.apiPrefix).to.equal(url.resolve(settings.get('apiUrl'), '/ewa/'))
 
 	# The intention of this spec is to quickly double check
 	# the internal _request() method works as expected.


### PR DESCRIPTION
Instead of relying on `resin-request` to know it.
