### PR TITLE
Upgrade to new resin-request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+### Changed
+
+- Isomorphic-fetch is no longer required, as `resin-request` now uses its own `fetch` implementation
+- **Breaking**: Timeouts in requests now use the Bluebird implementation. This changes how errors are thrown slightly: a Promise.TimeoutError is now thrown instead of a raw Error, with the message "operation timed out" instead of "timeout".
+
 ## [4.0.0] - 2016-11-24
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -29,12 +29,12 @@
   "devDependencies": {
     "coffee-script": "~1.11.0",
     "fetch-mock": "^5.1.5",
+    "fetch-ponyfill": "^3.0.2",
     "gulp": "^3.9.1",
     "gulp-coffee": "^2.3.1",
     "gulp-coffeelint": "^0.6.0",
     "gulp-mocha": "^3.0.0",
     "gulp-util": "^3.0.1",
-    "isomorphic-fetch": "^2.2.1",
     "karma": "^1.3.0",
     "mocha": "^3.0.0",
     "mochainon": "^1.0.0",
@@ -46,7 +46,7 @@
     "lodash": "^4.5.0",
     "pinejs-client": "^2.1.1",
     "resin-errors": "^2.0.0",
-    "resin-request": "^6.0.1",
+    "resin-request": "^7.0.0",
     "resin-token": "^3.0.0"
   }
 }

--- a/tests/pine.spec.coffee
+++ b/tests/pine.spec.coffee
@@ -1,10 +1,5 @@
-Promise = require('bluebird')
-global.Promise = Promise
-require('isomorphic-fetch')
-
 _ = require('lodash')
 m = require('mochainon')
-fetchMock = require('fetch-mock')
 Promise = require('bluebird')
 url = require('url')
 tokens = require('./fixtures/tokens.json')
@@ -15,10 +10,21 @@ IS_BROWSER = window?
 
 dataDirectory = null
 apiUrl = 'https://api.resin.io'
-if not IS_BROWSER
+if IS_BROWSER
+	# The browser mock assumes global fetch prototypes exist
+	# Can improve after https://github.com/wheresrhys/fetch-mock/issues/158
+	realFetchModule = require('fetch-ponyfill')({ Promise })
+	_.assign(global, _.pick(realFetchModule, 'Headers', 'Request', 'Response'))
+else
 	settings = require('resin-settings-client')
 	apiUrl = settings.get('apiUrl')
 	dataDirectory = settings.get('dataDirectory')
+
+fetchMock = require('fetch-mock').sandbox(Promise)
+# Promise sandbox config needs a little help. See:
+# https://github.com/wheresrhys/fetch-mock/issues/159#issuecomment-268249788
+fetchMock.fetchMock.Promise = Promise
+require('resin-request/build/utils').fetch = fetchMock.fetchMock # Can become just fetchMock after issue above is fixed.
 
 token = getToken({ dataDirectory })
 

--- a/tests/pine.spec.coffee
+++ b/tests/pine.spec.coffee
@@ -68,7 +68,7 @@ describe 'Pine:', ->
 
 					beforeEach ->
 						@pine = buildPineInstance()
-						fetchMock.get "^#{@pine.API_URL}/foo",
+						fetchMock.get "begin:#{@pine.API_URL}/foo",
 							body: hello: 'world'
 							headers:
 								'Content-Type': 'application/json'


### PR DESCRIPTION
Only spotted this module in my resin-sdk PR just before I left for holidays, but it needs updating too. Main change here is updating the tests to work with the new resin-request, since the existing global fetch stub no longer works.

This module does manage its dependencies differently to what I've done in [resin-register-device](https://github.com/resin-io-modules/resin-register-device/pull/28). We should make these consistent before this or that gets merged.

Currently this module takes `dataDirectory` as an option, and builds its own resin-request and resin-token instances, passing the dataDirectory in itself. `resin-register-device` meanwhile takes a prebuilt resin-request, and just uses it - the equivalent here would be to pass in working `resin-token` and `resin-request` instances directly.

Feels nicer to inject them imo. It would mean this module isn't coupled to the resin-request or resin-token constructor arguments, and lets you share resin-request and token instances directly (although I'm not sure that makes much runtime difference, it feels cleaner).

Theoretically it would also give us the option of unit testing this with a stub `resin-request` [as in resin-register-device](https://github.com/resin-io-modules/resin-register-device/blob/415269d65ed9619ba91997323b20ad79e5a8e6ff/tests/register.spec.coffee#L23), rather than integration testing it and stubbing fetch (which is why this currently has to duplicate the fetch-mock workarounds from `resin-request`). 'Theoretical' because while would be tidier, I think I prefer the more thorough test behaviour we have right now for this module, but it's nice to have the option.