### PR TITLE
Move to a DI approach for resin-request and resin-token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+- **Breaking**: Resin-Request and Resin-Token are now required to be injected, rather than being created internally.
 - Upgraded `pinejs-client` to 3.0.0, which adds support for dates.
 - Isomorphic-fetch is no longer required, as `resin-request` now uses its own `fetch` implementation
 - **Breaking**: Timeouts in requests now use the Bluebird implementation. This changes how errors are thrown slightly: a Promise.TimeoutError is now thrown instead of a raw Error, with the message "operation timed out" instead of "timeout".

--- a/README.md
+++ b/README.md
@@ -36,7 +36,9 @@ Instantiate the PineJS like that:
 ```
 var pine = require('resin-pine')({
   apiUrl: "https://api.resin.io/",
-  apiVersion: "v2"
+  apiVersion: "v2",
+  request: request, // An instantiated resin-request instance
+  token: token // An instantiated resin-token instance
 })
 ```
 

--- a/build/pine.js
+++ b/build/pine.js
@@ -19,7 +19,7 @@ limitations under the License.
 /**
  * @module pine
  */
-var PinejsClientCore, Promise, assign, defaults, errors, getPine, getRequest, getToken, isEmpty, url, utils,
+var PinejsClientCore, Promise, assign, defaults, errors, getPine, isEmpty, url, utils,
   extend = function(child, parent) { for (var key in parent) { if (hasProp.call(parent, key)) child[key] = parent[key]; } function ctor() { this.constructor = child; } ctor.prototype = parent.prototype; child.prototype = new ctor(); child.__super__ = parent.prototype; return child; },
   hasProp = {}.hasOwnProperty;
 
@@ -46,19 +46,9 @@ PinejsClientCore = require('pinejs-client/core')(utils, Promise);
 
 errors = require('resin-errors');
 
-getRequest = require('resin-request');
-
-getToken = require('resin-token');
-
 getPine = function(arg) {
-  var ResinPine, apiKey, apiPrefix, apiUrl, apiVersion, dataDirectory, pineInstance, ref, request, token;
-  ref = arg != null ? arg : {}, apiUrl = ref.apiUrl, apiVersion = ref.apiVersion, apiKey = ref.apiKey, dataDirectory = ref.dataDirectory;
-  token = getToken({
-    dataDirectory: dataDirectory
-  });
-  request = getRequest({
-    dataDirectory: dataDirectory
-  });
+  var ResinPine, apiKey, apiPrefix, apiUrl, apiVersion, pineInstance, ref, request, token;
+  ref = arg != null ? arg : {}, apiUrl = ref.apiUrl, apiVersion = ref.apiVersion, apiKey = ref.apiKey, request = ref.request, token = ref.token;
   apiPrefix = url.resolve(apiUrl, "/" + apiVersion + "/");
 
   /**

--- a/lib/pine.coffee
+++ b/lib/pine.coffee
@@ -33,12 +33,8 @@ url = require('url')
 Promise = require('bluebird')
 PinejsClientCore = require('pinejs-client/core')(utils, Promise)
 errors = require('resin-errors')
-getRequest = require('resin-request')
-getToken = require('resin-token')
 
-getPine = ({ apiUrl, apiVersion, apiKey, dataDirectory } = {}) ->
-	token = getToken({ dataDirectory })
-	request = getRequest({ dataDirectory })
+getPine = ({ apiUrl, apiVersion, apiKey, request, token } = {}) ->
 	apiPrefix = url.resolve(apiUrl, "/#{apiVersion}/")
 
 	###*

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "mochainon": "^1.0.0",
     "resin-config-karma": "^1.0.4",
     "resin-request": "^7.0.0",
-    "resin-settings-client": "^3.5.2",
     "resin-token": "^3.0.0",
     "temp": "^0.8.3"
   },

--- a/package.json
+++ b/package.json
@@ -39,13 +39,18 @@
     "mocha": "^3.0.0",
     "mochainon": "^1.0.0",
     "resin-config-karma": "^1.0.4",
-    "resin-settings-client": "^3.5.2"
+    "resin-request": "^7.0.0",
+    "resin-settings-client": "^3.5.2",
+    "resin-token": "^3.0.0",
+    "temp": "^0.8.3"
   },
   "dependencies": {
     "bluebird": "^3.3.1",
     "lodash": "^4.5.0",
     "pinejs-client": "^3.0.0",
-    "resin-errors": "^2.0.0",
+    "resin-errors": "^2.0.0"
+  },
+  "peerDependencies": {
     "resin-request": "^7.0.0",
     "resin-token": "^3.0.0"
   }

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "mocha": "^3.0.0",
     "mochainon": "^1.0.0",
     "resin-config-karma": "^1.0.4",
-    "resin-request": "^7.0.0",
+    "resin-request": "^8.0.0",
     "resin-token": "^3.0.0",
     "temp": "^0.8.3"
   },
@@ -50,7 +50,7 @@
     "resin-errors": "^2.0.0"
   },
   "peerDependencies": {
-    "resin-request": "^7.0.0",
+    "resin-request": "^8.0.0",
     "resin-token": "^3.0.0"
   }
 }

--- a/tests/pine.spec.coffee
+++ b/tests/pine.spec.coffee
@@ -3,7 +3,6 @@ m = require('mochainon')
 Promise = require('bluebird')
 url = require('url')
 tokens = require('./fixtures/tokens.json')
-getToken = require('resin-token')
 getPine = require('../lib/pine')
 
 IS_BROWSER = window?
@@ -25,7 +24,7 @@ fetchMock = require('fetch-mock').sandbox(Promise)
 fetchMock.fetchMock.Promise = Promise
 require('resin-request/build/utils').fetch = fetchMock.fetchMock # Can become just fetchMock after issue above is fixed.
 
-token = getToken({ dataDirectory })
+token = require('resin-token')({ dataDirectory })
 request = require('resin-request')({ dataDirectory })
 
 apiVersion = 'v2'

--- a/tests/pine.spec.coffee
+++ b/tests/pine.spec.coffee
@@ -25,7 +25,7 @@ fetchMock.fetchMock.Promise = Promise
 require('resin-request/build/utils').fetch = fetchMock.fetchMock # Can become just fetchMock after issue above is fixed.
 
 token = require('resin-token')({ dataDirectory })
-request = require('resin-request')({ dataDirectory })
+request = require('resin-request')({ token })
 
 apiVersion = 'v2'
 

--- a/tests/pine.spec.coffee
+++ b/tests/pine.spec.coffee
@@ -16,9 +16,8 @@ if IS_BROWSER
 	realFetchModule = require('fetch-ponyfill')({ Promise })
 	_.assign(global, _.pick(realFetchModule, 'Headers', 'Request', 'Response'))
 else
-	settings = require('resin-settings-client')
-	apiUrl = settings.get('apiUrl')
-	dataDirectory = settings.get('dataDirectory')
+	temp = require('temp').track()
+	dataDirectory = temp.mkdirSync()
 
 fetchMock = require('fetch-mock').sandbox(Promise)
 # Promise sandbox config needs a little help. See:
@@ -27,12 +26,13 @@ fetchMock.fetchMock.Promise = Promise
 require('resin-request/build/utils').fetch = fetchMock.fetchMock # Can become just fetchMock after issue above is fixed.
 
 token = getToken({ dataDirectory })
+request = require('resin-request')({ dataDirectory })
 
 apiVersion = 'v2'
 
 buildPineInstance = (extraOpts) ->
 	getPine _.assign {
-		apiUrl, apiVersion, dataDirectory,
+		apiUrl, apiVersion, request, token
 		apiKey: null
 	}, extraOpts
 


### PR DESCRIPTION
This moves Resin-Pine to DI, as discussed in https://github.com/resin-io-modules/resin-request/issues/85