### PR TITLE
Fix test request mocking

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,7 +16,7 @@ environment:
 
 install:
   - ps: Install-Product node $env:nodejs_version x64
-  - npm -g install npm
+  - npm -g install npm@5
   - set PATH=%APPDATA%\npm;%PATH%
   - npm install
 

--- a/circle.yml
+++ b/circle.yml
@@ -18,20 +18,20 @@ buildSteps: &buildSteps
 jobs:
   "node-6":
     docker:
-      - image: circleci/node:6
+      - image: circleci/node:6-browsers
     working_directory: ~/node-6
     steps: *buildSteps
 
   "node-8":
     docker:
-      - image: circleci/node:8
+      - image: circleci/node:8-browsers
     working_directory: ~/node-8
     steps: *buildSteps
 
   deploy:
     # For this to work NPM_TOKEN must be set for the account used for publishing
     docker:
-      - image: circleci/node:6
+      - image: circleci/node:6-browsers
     steps:
       - attach_workspace:
           at: $CIRCLE_WORKING_DIRECTORY

--- a/karma.conf.coffee
+++ b/karma.conf.coffee
@@ -3,7 +3,13 @@ packageJSON = require('./package.json')
 
 module.exports = (config) ->
 	karmaConfig.plugins.push(require('karma-chrome-launcher'))
-	karmaConfig.browsers = ['ChromeHeadless']
+	karmaConfig.browsers = ['ChromeHeadlessCustom']
+	karmaConfig.customLaunchers =
+		ChromeHeadlessCustom:
+			base: 'ChromeHeadless'
+			flags: [
+				'--no-sandbox'
+			]
 
 	karmaConfig.logLevel = config.LOG_INFO
 

--- a/karma.conf.coffee
+++ b/karma.conf.coffee
@@ -2,7 +2,11 @@ karmaConfig = require('resin-config-karma')
 packageJSON = require('./package.json')
 
 module.exports = (config) ->
+	karmaConfig.plugins.push(require('karma-chrome-launcher'))
+	karmaConfig.browsers = ['ChromeHeadless']
+
 	karmaConfig.logLevel = config.LOG_INFO
+
 	karmaConfig.sauceLabs =
 		testName: "#{packageJSON.name} v#{packageJSON.version}"
 	karmaConfig.client =

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "build": "gulp build",
     "test": "npm run test-node && npm run test-browser",
     "test-node": "gulp test",
-    "test-browser": "karma start",
+    "test-browser": "mockttp -c karma start",
     "prepublish": "npm test && npm run build"
   },
   "author": "Juan Cruz Viotti <juan@resin.io>",
@@ -36,10 +36,10 @@
     "karma": "^1.3.0",
     "mocha": "^3.0.0",
     "mochainon": "^1.0.0",
+    "mockttp": "^0.9.1",
     "resin-auth": "^2.0.0",
     "resin-config-karma": "^1.0.4",
-    "resin-fetch-mock": "^1.0.1",
-    "resin-request": "^9.0.0",
+    "resin-request": "^9.3.1",
     "temp": "^0.8.3"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "gulp-mocha": "^3.0.0",
     "gulp-util": "^3.0.1",
     "karma": "^1.3.0",
+    "karma-chrome-launcher": "^2.2.0",
     "mocha": "^3.0.0",
     "mochainon": "^1.0.0",
     "mockttp": "^0.9.1",


### PR DESCRIPTION
Connects to #45 

This sticks with the existing resin-config-karma version, but moves it to Chrome (required because resin-request now uses dependencies that use `const`), and changes the Circle base images to ones with Chrome preinstalled to make that work.