### PR TITLE
Add an anonymous flag to resin-pine to allow anonymous pine requests

### DIFF
--- a/build/pine.js
+++ b/build/pine.js
@@ -74,12 +74,19 @@ getPine = function(arg) {
     ResinPine.prototype._request = function(options) {
       defaults(options, {
         apiKey: apiKey,
-        baseUrl: apiUrl
+        baseUrl: apiUrl,
+        sendToken: !options.anonymous
       });
-      return auth.hasKey().then(function(hasKey) {
-        if (!hasKey && isEmpty(apiKey)) {
-          throw new errors.ResinNotLoggedIn();
+      return Promise["try"](function() {
+        if (options.anonymous) {
+          return;
         }
+        return auth.hasKey().then(function(hasKey) {
+          if (!hasKey && isEmpty(apiKey)) {
+            throw new errors.ResinNotLoggedIn();
+          }
+        });
+      }).then(function() {
         return request.send(options).get('body');
       });
     };

--- a/lib/pine.coffee
+++ b/lib/pine.coffee
@@ -54,10 +54,15 @@ getPine = ({ apiUrl, apiVersion, apiKey, request, auth } = {}) ->
 			defaults options,
 				apiKey: apiKey
 				baseUrl: apiUrl
+				sendToken: !options.anonymous
 
-			auth.hasKey().then (hasKey) ->
-				if not hasKey and isEmpty(apiKey)
-					throw new errors.ResinNotLoggedIn()
+			Promise.try ->
+				return if options.anonymous
+
+				auth.hasKey().then (hasKey) ->
+					if not hasKey and isEmpty(apiKey)
+						throw new errors.ResinNotLoggedIn()
+			.then ->
 				return request.send(options).get('body')
 
 	pineInstance = new ResinPine

--- a/tests/pine.spec.coffee
+++ b/tests/pine.spec.coffee
@@ -103,7 +103,9 @@ describe 'Pine:', ->
 
 					beforeEach ->
 						@pine = buildPineInstance(mockServer.url)
-						mockServer.get('/foo').withHeaders({ 'Authorization': "Bearer #{tokens.johndoe.token}" }).thenJSON(200, hello: 'world')
+						mockServer.get('/foo')
+							.withHeaders({ 'Authorization': "Bearer #{tokens.johndoe.token}" })
+							.thenJSON(200, hello: 'world')
 						mockServer.get('/foo').thenReply(401, 'Unauthorized')
 
 					it 'should eventually become the response body', ->

--- a/tests/pine.spec.coffee
+++ b/tests/pine.spec.coffee
@@ -75,6 +75,14 @@ describe 'Pine:', ->
 								url: '/foo'
 							m.chai.expect(promise).to.be.rejectedWith('You have to log in')
 
+						it 'should be successful, if sent anonymously', ->
+							promise = @pine._request
+								baseUrl: @pine.API_URL
+								method: 'GET'
+								url: '/foo'
+								anonymous: true
+							m.chai.expect(promise).to.become(hello: 'world')
+
 					describe 'given there is an api key', ->
 						beforeEach ->
 							@pine = buildPineInstance(mockServer.url, apiKey: '123456789')
@@ -95,7 +103,8 @@ describe 'Pine:', ->
 
 					beforeEach ->
 						@pine = buildPineInstance(mockServer.url)
-						mockServer.get('/foo').thenJSON(200, hello: 'world')
+						mockServer.get('/foo').withHeaders({ 'Authorization': "Bearer #{tokens.johndoe.token}" }).thenJSON(200, hello: 'world')
+						mockServer.get('/foo').thenReply(401, 'Unauthorized')
 
 					it 'should eventually become the response body', ->
 						promise = @pine._request
@@ -103,6 +112,14 @@ describe 'Pine:', ->
 							method: 'GET'
 							url: '/foo'
 						m.chai.expect(promise).to.eventually.become(hello: 'world')
+
+					it 'should not send the auth token, if using an anonymous flag', ->
+						promise = @pine._request
+							baseUrl: @pine.API_URL
+							method: 'GET'
+							url: '/foo'
+							anonymous: true
+						m.chai.expect(promise).to.be.rejectedWith('Request error: Unauthorized')
 
 				describe 'given a POST endpoint that mirrors the request body', ->
 


### PR DESCRIPTION
Before this change, it was impossible to make unauthenticated pine requests.

With this change, you can now make anonymous requests like so:

```ts
pine.get({ resource: 'plan', passthrough: { anonymous: true } })
```

This `anonymous` options means that:
* requests are sent without complaint if you have no token configured
* if you do have a token configured, it's not sent with the request

Fixes #49 