### PR TITLE
Rename everything 'resin' to 'balena'

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,31 +1,31 @@
-resin-pine
+balena-pine
 ----------
 
-[![npm version](https://badge.fury.io/js/resin-pine.svg)](http://badge.fury.io/js/resin-pine)
-[![dependencies](https://david-dm.org/resin-io-modules/resin-pine.png)](https://david-dm.org/resin-io-modules/resin-pine.png)
-[![Circle Build Status](https://circleci.com/gh/resin-io-modules/resin-pine/tree/master.svg?style=shield)](https://circleci.com/gh/resin-io-modules/resin-pine)
-[![Appveyor Build status](https://ci.appveyor.com/api/projects/status/cwh3jfc7vur5bvmu/branch/master?svg=true)](https://ci.appveyor.com/project/resin-io/resin-pine/branch/master)
+[![npm version](https://badge.fury.io/js/balena-pine.svg)](http://badge.fury.io/js/balena-pine)
+[![dependencies](https://david-dm.org/balena-io-modules/balena-pine.png)](https://david-dm.org/balena-io-modules/balena-pine.png)
+[![Circle Build Status](https://circleci.com/gh/balena-io-modules/balena-pine/tree/master.svg?style=shield)](https://circleci.com/gh/balena-io-modules/balena-pine)
+[![Appveyor Build status](https://ci.appveyor.com/api/projects/status/cwh3jfc7vur5bvmu/branch/master?svg=true)](https://ci.appveyor.com/project/balena-io/balena-pine/branch/master)
 
-Join our online chat at [![Gitter chat](https://badges.gitter.im/resin-io/chat.png)](https://gitter.im/resin-io/chat)
+Join our online chat at [![Gitter chat](https://badges.gitter.im/balena-io/chat.png)](https://gitter.im/balena-io/chat)
 
-Resin.io PineJS client.
+Balena PineJS client.
 
 Role
 ----
 
-The intention of this module is to provide a ready to use subclass of [pinejs-client-js](https://github.com/resin-io/pinejs-client-js) which uses [resin-request](https://github.com/resin-io-modules/resin-request).
+The intention of this module is to provide a ready to use subclass of [pinejs-client-js](https://github.com/balena-io/pinejs-client-js) which uses [balena-request](https://github.com/balena-io-modules/balena-request).
 
 **THIS MODULE IS LOW LEVEL AND IS NOT MEANT TO BE USED BY END USERS DIRECTLY**.
 
-Unless you know what you're doing, use the [Resin SDK](https://github.com/resin-io/resin-sdk) instead.
+Unless you know what you're doing, use the [balena SDK](https://github.com/balena-io/balena-sdk) instead.
 
 Installation
 ------------
 
-Install `resin-pine` by running:
+Install `balena-pine` by running:
 
 ```sh
-$ npm install --save resin-pine
+$ npm install --save balena-pine
 ```
 
 Documentation
@@ -34,28 +34,28 @@ Documentation
 Instantiate the PineJS like that:
 
 ```
-var pine = require('resin-pine')({
-  apiUrl: "https://api.resin.io/",
+var pine = require('balena-pine')({
+  apiUrl: "https://api.balena-cloud.com/",
   apiVersion: "v2",
-  request: request, // An instantiated resin-request instance
-  auth: auth // An instantiated resin-auth instance
+  request: request, // An instantiated balena-request instance
+  auth: auth // An instantiated balena-auth instance
 })
 ```
 
 Where the factory method accepts the following options:
-* `apiUrl`, string, **required**, is the Resin.io API url like `https://api.resin.io/`,
+* `apiUrl`, string, **required**, is the balena API url like `https://api.balena-cloud.com/`,
 * `apiVersion`, string, **required**, is the version of the API to talk to, like `v2`. The current stable version is `v2`,
 * `apiKey`, string, *optional*, is the API key to make the requests with,
-* `request`, object, an instantiated [resin-request](https://github.com/resin-io/resin-request) instance.
-* `auth`, object, an instantiated [resin-auth](https://github.com/resin-io-modules/resin-auth) instance.
+* `request`, object, an instantiated [balena-request](https://github.com/balena-io/balena-request) instance.
+* `auth`, object, an instantiated [balena-auth](https://github.com/balena-io-modules/balena-auth) instance.
 
 
-Head over to [pinejs-client-js](https://github.com/resin-io/pinejs-client-js) for the returned PineJS instance documentation.
+Head over to [pinejs-client-js](https://github.com/balena-io/pinejs-client-js) for the returned PineJS instance documentation.
 
 Support
 -------
 
-If you're having any problem, please [raise an issue](https://github.com/resin-io-modules/resin-pine/issues/new) on GitHub and the Resin.io team will be happy to help.
+If you're having any problem, please [raise an issue](https://github.com/balena-io-modules/balena-pine/issues/new) on GitHub and the balena team will be happy to help.
 
 Tests
 -----
@@ -69,8 +69,8 @@ $ npm test
 Contribute
 ----------
 
-- Issue Tracker: [github.com/resin-io-modules/resin-pine/issues](https://github.com/resin-io-modules/resin-pine/issues)
-- Source Code: [github.com/resin-io-modules/resin-pine](https://github.com/resin-io-modules/resin-pine)
+- Issue Tracker: [github.com/balena-io-modules/balena-pine/issues](https://github.com/balena-io-modules/balena-pine/issues)
+- Source Code: [github.com/balena-io-modules/balena-pine](https://github.com/balena-io-modules/balena-pine)
 
 Before submitting a PR, please make sure that you include tests, and that [coffeelint](http://www.coffeelint.org/) runs without any warning:
 

--- a/karma.conf.coffee
+++ b/karma.conf.coffee
@@ -1,4 +1,4 @@
-getKarmaConfig = require('resin-config-karma')
+getKarmaConfig = require('balena-config-karma')
 packageJSON = require('./package.json')
 
 getKarmaConfig.DEFAULT_WEBPACK_CONFIG.externals = fs: true

--- a/lib/pine.coffee
+++ b/lib/pine.coffee
@@ -1,5 +1,5 @@
 ###
-Copyright 2016 Resin.io
+Copyright 2016 Balena
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -25,23 +25,23 @@ url = require('url')
 Promise = require('bluebird')
 { PinejsClientCoreFactory } = require('pinejs-client-core')
 PinejsClientCore = PinejsClientCoreFactory(Promise)
-errors = require('resin-errors')
+errors = require('balena-errors')
 
 getPine = ({ apiUrl, apiVersion, apiKey, request, auth } = {}) ->
 	apiPrefix = url.resolve(apiUrl, "/#{apiVersion}/")
 
 	###*
 	# @class
-	# @classdesc A PineJS Client subclass to communicate with Resin.io.
+	# @classdesc A PineJS Client subclass to communicate with balena.
 	# @private
 	#
 	# @description
-	# This subclass makes use of the [resin-request](https://github.com/resin-io-modules/resin-request) project.
+	# This subclass makes use of the [balena-request](https://github.com/balena-io-modules/balena-request) project.
 	###
-	class ResinPine extends PinejsClientCore
+	class BalenaPine extends PinejsClientCore
 
 		###*
-		# @summary Perform a network request to Resin.io.
+		# @summary Perform a network request to balena.
 		# @method
 		# @private
 		#
@@ -61,11 +61,11 @@ getPine = ({ apiUrl, apiVersion, apiKey, request, auth } = {}) ->
 
 				auth.hasKey().then (hasKey) ->
 					if not hasKey and isEmpty(apiKey)
-						throw new errors.ResinNotLoggedIn()
+						throw new errors.BalenaNotLoggedIn()
 			.then ->
 				return request.send(options).get('body')
 
-	pineInstance = new ResinPine
+	pineInstance = new BalenaPine
 		apiPrefix: apiPrefix
 
 	assign pineInstance,

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "mochainon": "^2.0.0",
     "mockttp": "^0.9.1",
     "require-npm4-to-publish": "^1.0.0",
-    "resin-config-karma": "^2.2.0",
+    "balena-config-karma": "^2.2.0",
     "temp": "^0.8.3"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,14 +1,15 @@
 {
-  "name": "resin-pine",
+  "name": "balena-pine",
   "version": "8.1.0",
-  "description": "Resin.io PineJS client.",
+  "description": "Balena PineJS client.",
   "main": "build/pine.js",
-  "homepage": "https://github.com/resin-io-modules/resin-pine",
+  "homepage": "https://github.com/balena-io-modules/balena-pine",
   "repository": {
     "type": "git",
-    "url": "git://github.com/resin-io-modules/resin-pine.git"
+    "url": "git://github.com/balena-io-modules/balena-pine.git"
   },
   "keywords": [
+    "balena",
     "resin",
     "pine",
     "client"
@@ -25,9 +26,11 @@
     "prepublish": "require-npm4-to-publish",
     "prepublishOnly": "npm test && npm run build"
   },
-  "author": "Juan Cruz Viotti <juan@resin.io>",
+  "author": "Juan Cruz Viotti <juan@balena.io>",
   "license": "Apache-2.0",
   "devDependencies": {
+    "balena-auth": "^3.0.0",
+    "balena-request": "^10.0.0",
     "coffeescript": "~1.12.2",
     "gulp": "^3.9.1",
     "gulp-coffee": "^2.3.1",
@@ -40,19 +43,17 @@
     "mochainon": "^2.0.0",
     "mockttp": "^0.9.1",
     "require-npm4-to-publish": "^1.0.0",
-    "resin-auth": "^2.0.0",
     "resin-config-karma": "^2.2.0",
-    "resin-request": "^9.3.3",
     "temp": "^0.8.3"
   },
   "dependencies": {
+    "balena-errors": "^3.0.0",
     "bluebird": "^3.5.2",
     "lodash": "^4.17.11",
-    "pinejs-client-core": "^5.3.4",
-    "resin-errors": "^2.13.0"
+    "pinejs-client-core": "^5.3.4"
   },
   "peerDependencies": {
-    "resin-auth": "^2.0.0",
-    "resin-request": "^9.0.0"
+    "balena-auth": "^3.0.0",
+    "balena-request": "^10.0.0"
   }
 }

--- a/tests/pine.spec.coffee
+++ b/tests/pine.spec.coffee
@@ -3,8 +3,8 @@ m = require('mochainon')
 url = require('url')
 tokens = require('./fixtures/tokens.json')
 getPine = require('../lib/pine')
-ResinAuth = require('resin-auth')['default']
-getRequest = require('resin-request')
+BalenaAuth = require('balena-auth')['default']
+getRequest = require('balena-request')
 
 mockServer = require('mockttp').getLocal()
 
@@ -15,7 +15,7 @@ if not IS_BROWSER
 	temp = require('temp').track()
 	dataDirectory = temp.mkdirSync()
 
-auth = new ResinAuth({ dataDirectory })
+auth = new BalenaAuth({ dataDirectory })
 
 request = getRequest({ auth })
 
@@ -43,7 +43,7 @@ describe 'Pine:', ->
 
 	# The intention of this spec is to quickly double check
 	# the internal _request() method works as expected.
-	# The nitty grits of request are tested in resin-request.
+	# The nitty grits of request are tested in balena-request.
 
 	describe 'given a /whoami endpoint', ->
 


### PR DESCRIPTION
The only functional change is that the balena-errors bump means we now return Balena errors, not Resin ones.

As with balena-auth/request, changing this is required because the module is exposed from the SDK as sdk.pine, and these error types will potentially be exposed by SDK calls too.

---

Fixes #51
Change-type: major
Signed-off-by: Tim Perry <tim@balena.io>