### PR TITLE
Bump pinejs client to add the 'upsert' method, requires Pinejs ^10.19.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "balena-errors": "^4.1.0",
     "bluebird": "^3.5.2",
     "lodash": "^4.17.11",
-    "pinejs-client-core": "^5.5.4"
+    "pinejs-client-core": "^5.6.0"
   },
   "peerDependencies": {
     "balena-auth": "^3.0.0",


### PR DESCRIPTION
Change-type:  minor
Depends-on: balena-io/pinejs-client-js#81
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>