### PR TITLE
Convert karma.conf to js & bump balena-config-karma to v3

### DIFF
--- a/karma.conf.coffee
+++ b/karma.conf.coffee
@@ -1,8 +1,0 @@
-getKarmaConfig = require('balena-config-karma')
-packageJSON = require('./package.json')
-
-getKarmaConfig.DEFAULT_WEBPACK_CONFIG.externals = fs: true
-
-module.exports = (config) ->
-	karmaConfig = getKarmaConfig(packageJSON)
-	config.set(karmaConfig)

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,0 +1,13 @@
+var getKarmaConfig = require('balena-config-karma');
+
+var packageJSON = require('./package.json');
+
+getKarmaConfig.DEFAULT_WEBPACK_CONFIG.externals = {
+  fs: true
+};
+
+module.exports = function(config) {
+  var karmaConfig;
+  karmaConfig = getKarmaConfig(packageJSON);
+  return config.set(karmaConfig);
+};

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "devDependencies": {
     "@balena/lint": "^4.1.1",
     "balena-auth": "^3.1.0",
-    "balena-config-karma": "^2.3.1",
+    "balena-config-karma": "^3.0.0",
     "balena-request": "^10.0.4",
     "coffeescript": "^1.12.7",
     "karma": "^3.1.4",


### PR DESCRIPTION
~~Had to drop node 8 tests since the updated karma-sauce-launcher in balena-config-karma doesn't run there.~~

Change-type: patch
Depends-on: https://github.com/balena-io-modules/resin-config-karma/pull/12
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>
