### PR TITLE
Update pinejs-client-core to 6.9.0 to support getOrCreate()

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   "dependencies": {
     "@balena/es-version": "^1.0.0",
     "balena-errors": "^4.2.1",
-    "pinejs-client-core": "^6.6.1",
+    "pinejs-client-core": "^6.9.0",
     "tslib": "^2.0.1"
   },
   "peerDependencies": {


### PR DESCRIPTION
Update pinejs-client-core from 6.6.1 to 6.9.0

Change-type: minor
See: https://github.com/balena-io-modules/pinejs-client-js/pull/100
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>